### PR TITLE
feat Add S3 bucket testbucketwithbackstage configuration

### DIFF
--- a/infrastructure/s3/README.md
+++ b/infrastructure/s3/README.md
@@ -1,0 +1,63 @@
+# AWS S3 Bucket Infrastructure
+
+This directory contains Terraform configuration for creating an AWS S3 bucket with secure defaults.
+
+## Features
+
+- Creates an S3 bucket with the specified name
+- Blocks all public access by default
+- Enables server-side encryption using AES-256
+- Optional versioning support
+- Configurable tags
+- Region-specific deployment
+
+## Configuration
+
+The following variables can be configured:
+
+- `bucket_name`: Name of the S3 bucket (must be globally unique)
+- `region`: AWS region where the bucket will be created
+- `environment`: Deployment environment (dev, staging, prod)
+- `versioning`: Enable versioning for the S3 bucket (default: false)
+- `tags`: Additional tags for the S3 bucket (default: {})
+
+## Security Features
+
+1. Public Access Block
+   - Blocks all public ACLs
+   - Blocks public policy
+   - Ignores public ACLs
+   - Restricts public bucket policies
+
+2. Encryption
+   - Server-side encryption enabled by default
+   - Uses AES-256 encryption algorithm
+
+## Prerequisites
+
+- AWS credentials configured
+- Terraform >= 1.0
+- AWS provider ~> 4.0
+
+## Usage
+
+1. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+
+2. Review the plan:
+   ```bash
+   terraform plan
+   ```
+
+3. Apply the configuration:
+   ```bash
+   terraform apply
+   ```
+
+## Outputs
+
+- `bucket_name`: Name of the created S3 bucket
+- `bucket_arn`: ARN of the created S3 bucket
+- `versioning_enabled`: Whether versioning is enabled for the bucket

--- a/infrastructure/s3/main.tf
+++ b/infrastructure/s3/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  backend "s3" {
+    # This will be configured during deployment
+  }
+}
+
+provider "aws" {
+  region = var.region
+  
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_id}:role/GitHubActionsRole"
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+
+  tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy  = "terraform"
+    },
+    var.tags
+  )
+}
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  count = var.versioning_enabled ? 1 : 0
+  
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Add server-side encryption by default
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Block public access by default
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/infrastructure/s3/outputs.tf
+++ b/infrastructure/s3/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_name" {
+  description = "Name of the created S3 bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the created S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}
+
+output "versioning_enabled" {
+  description = "Whether versioning is enabled for the bucket"
+  value       = length(aws_s3_bucket_versioning.this) > 0 ? true : false
+}

--- a/infrastructure/s3/variables.tf
+++ b/infrastructure/s3/variables.tf
@@ -1,0 +1,30 @@
+variable "account_id" {
+  description = "AWS Account ID where the S3 bucket will be created"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region where the S3 bucket will be created"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (e.g., development, staging, production)"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "versioning_enabled" {
+  description = "Whether to enable versioning for the S3 bucket"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the S3 bucket"
+  type        = map(string)
+  default     = {}


### PR DESCRIPTION
This PR adds Terraform configuration for a new S3 bucket with the following properties:

- Bucket Name: testbucketwithbackstage
- Region: us-east-1
- Environment: dev
- Versioning: false
- Account ID: 038751964618

Files Added:
- infrastructure/s3/main.tf - Main Terraform configuration
- infrastructure/s3/variables.tf - Variable definitions
- infrastructure/s3/outputs.tf - Output definitions
- infrastructure/s3/README.md - Documentation

Please review and merge to deploy the S3 bucket infrastructure.
